### PR TITLE
use openapi-spec-validator instead of swagger-validator

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -11,7 +11,6 @@ egg-info:
 pull-images:
 	docker pull consul
 	docker pull rabbitmq
-	docker pull swaggerapi/swagger-validator
 	docker pull wazopbx/wait
 	docker pull wazopbx/wazo-auth-mock
 

--- a/integration_tests/assets/docker-compose.documentation.override.yml
+++ b/integration_tests/assets/docker-compose.documentation.override.yml
@@ -3,12 +3,6 @@ services:
   sync:
     depends_on:
       - plugind
-      - swagger-validator
       - rabbitmq
     environment:
-      TARGETS: "rabbitmq:5672 plugind:9503 swagger-validator:8080"
-
-  swagger-validator:
-    image: swaggerapi/swagger-validator
-    ports:
-      - "8080"
+      TARGETS: "rabbitmq:5672 plugind:9503"

--- a/integration_tests/suite/test_documentation.py
+++ b/integration_tests/suite/test_documentation.py
@@ -1,12 +1,16 @@
-# Copyright 2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import logging
 import requests
-import pprint
+import yaml
 
-from hamcrest import assert_that, empty
+from openapi_spec_validator import validate_v2_spec
 
 from .test_api import BaseIntegrationTest
+
+logger = logging.getLogger('openapi_spec_validator')
+logger.setLevel(logging.INFO)
 
 
 class TestDocumentation(BaseIntegrationTest):
@@ -14,11 +18,7 @@ class TestDocumentation(BaseIntegrationTest):
     asset = 'documentation'
 
     def test_documentation_errors(self):
-        api_url = 'https://plugind:9503/0.2/api/api.yml'
-        self.validate_api(api_url)
-
-    def validate_api(self, url):
-        validator_port = self.service_port(8080, 'swagger-validator')
-        validator_url = 'http://localhost:{port}/debug'.format(port=validator_port)
-        response = requests.get(validator_url, params={'url': url})
-        assert_that(response.json(), empty(), pprint.pformat(response.json()))
+        port = self.service_port(9503, 'plugind')
+        api_url = 'https://localhost:{port}/0.2/api/api.yml'.format(port=port)
+        api = requests.get(api_url, verify=False)
+        validate_v2_spec(yaml.safe_load(api.text))

--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -1,10 +1,11 @@
-docker-compose
-kombu
-nose
-pyhamcrest
-requests
 git+https://github.com/wazo-pbx/xivo-test-helpers.git
 git+https://github.com/wazo-pbx/xivo-lib-rest-client.git
 git+https://github.com/wazo-pbx/wazo-plugind-client.git
-stevedore
+docker-compose
+kombu
 mock
+nose
+openapi-spec-validator
+pyhamcrest
+requests
+stevedore


### PR DESCRIPTION
reason: openapi-spec-validator catch more errors