### PR TITLE
test: increase tries for working tests

### DIFF
--- a/integration_tests/suite/test_plugin_installation.py
+++ b/integration_tests/suite/test_plugin_installation.py
@@ -471,7 +471,7 @@ class TestPluginInstallation(BaseIntegrationTest):
                 ),
             )
 
-        until.assert_(assert_received, events, tries=5)
+        until.assert_(assert_received, events, tries=10)
 
     def test_when_uninstall_works(self):
         self.install_plugin(url='file:///data/git/repo', method='git', _async=False)
@@ -504,7 +504,7 @@ class TestPluginInstallation(BaseIntegrationTest):
                 ),
             )
 
-        until.assert_(assert_received, events, tries=5)
+        until.assert_(assert_received, events, tries=10)
 
         build_success_exists = self.exists_in_container('/tmp/results/build_success')
         package_success_exists = self.exists_in_container(


### PR DESCRIPTION
why: working action (install or uninstall) may require more time to be
executed, especially when host is slow