### PR TITLE
WP-2120-remove-pkg-resources

### DIFF
--- a/wazo_plugind/http.py
+++ b/wazo_plugind/http.py
@@ -1,7 +1,8 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
+from importlib.resources import files
 
 import requests
 import yaml
@@ -9,7 +10,6 @@ from flask import Flask, make_response, request
 from flask_cors import CORS
 from flask_restful import Api, Resource
 from marshmallow import ValidationError
-from pkg_resources import resource_string
 from werkzeug.local import LocalProxy as Proxy
 from xivo import http_helpers
 from xivo.auth_verifier import required_acl, required_tenant
@@ -233,7 +233,7 @@ class Swagger(_BaseResource):
     def get(self):
         try:
             api_spec = yaml.load(
-                resource_string(self.api_package, self.api_filename),
+                files(self.api_package).joinpath(self.api_filename).read_bytes(),
                 Loader=yaml.FullLoader,
             )
         except OSError:


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/xivo-lib-python/pull/175

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small internal change to how the OpenAPI YAML is read from package resources; main risk is packaging/runtime compatibility if the resource path isn’t included as expected.
> 
> **Overview**
> Removes the `pkg_resources.resource_string` dependency and switches Swagger spec loading to `importlib.resources.files(...).read_bytes()` when serving `/api/api.yml`.
> 
> Also updates the copyright year to 2026.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cb6dbdc5d9324afbd917ee7cd1e293d72057793. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->